### PR TITLE
Add --nolog option to silence log file.

### DIFF
--- a/src/nettfiske.rs
+++ b/src/nettfiske.rs
@@ -23,7 +23,11 @@ impl Nettfiske {
         }
     }
 
-    pub fn setup_logger(&self) -> Result<(), fern::InitError> {
+    pub fn setup_logger(&self, enable: bool) -> Result<(), fern::InitError> {
+        if !enable {
+            return Ok(());
+        }
+
         fern::Dispatch::new()
             .format(|out, message, _record| {
                 out.finish(format_args!(


### PR DESCRIPTION
In our use case we don't need the log file, so I added an option to disable it.

TBH I'm not too happy with this quick solution, it would be better to be able to inject the logger into the Nettfiske instance, and then have the app itself configure how logging should be done. If you want I'll be happy to do the necessary refactoring. If not I'll leave it like this, unless you have any gripes about it.